### PR TITLE
PR Riboulet Tristan

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ Ainsi, vous pourriez obtenir jusqu'à 25 points (cappés à 20) si vous réalise
 Entrez ici (par PR) vos prénom, nom, et le lien vers votre repository.
 
 1. [Henri Aulait](https://github.com/user/repo) https://github.com/user/repo
+2. [Tristan Riboulet](https://github.com/TristanRib/devops-docker-tp)

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,15 +4,25 @@
 # This image likely contains network utilities like netstat, ifconfig, etc.
 FROM donch/net-tools
 
+# D'après les layers de l'image, nous somme sur alpine, ajout du package pour les users
+RUN apk add --no-cache shadow
+
 # Copy the start.sh script from the local file system into the /bin directory of the image.
 # This script will be run when a container is started from this image.
 COPY start.sh /bin/start.sh
+
+# Permet l'éxécution du script au lancement du container par tout le monde
+RUN chmod +x /bin/start.sh
 
 # Expose port 4321 in the container.
 # This makes the port accessible to processes outside of the container.
 EXPOSE 4321
 
-USER root
+# Ajout du user www pour remplacer root qui pose problème
+RUN useradd -ms /bin/bash www
+
+# Utilisation du user www
+USER www
 
 # Set /bin/start.sh as the entrypoint of the image.
 # The entrypoint is the command that is run when a container is started from this image.

--- a/src/start.sh
+++ b/src/start.sh
@@ -7,8 +7,8 @@ set -eux
 # 'u' option treats unset variables and parameters as an error.
 # 'x' option prints each command that gets executed to the terminal, useful for debugging.
 
-touch /home/www/started.time
-# This command creates a file named 'started.time' in the '/home/www' directory.
+touch /tmp/started.time
+# This command creates a file named 'started.time' in the '/temp' directory.
 # If the file already exists, the command does not change the file but updates its access and modification timestamps.
 
 if [ $? -ne 0 ]; then
@@ -17,7 +17,7 @@ fi
 # This conditional statement checks the exit status of the last command (touch command in this case).
 # If the exit status is not zero, which indicates an error, the script will exit immediately.
 
-date > /home/www/started.time
+date > /tmp/started.time
 # This command writes the current date and time to the 'started.time' file.
 # The '>' operator is used to redirect the output of the 'date' command to the file.
 


### PR DESCRIPTION
Fait sur wsl2 en local.

### Validator.sh

Validator.sh sert à valider les images du projet.

1. Une ligne pour set les options du shell. Ici, on exit à chaque erreur, tout ce qui n'est pas défini est considéré comme une erreur et enfin si une instruction échoue dans une pipeline, alors toute la pipeline est échouée.
2. Crée une variable IMG avec comme valeur le PID du shell actuel.
3. Build une image docker du dockerfile dans ./src avec comme tag la variable IMG.
4. Run de l'image IMG avec override de l'entyrpoint par whoami. Ce run est utilisé pour la simple vérification du user.
5. Si la sortie de la commande précédente faut root, alors echo un message d'érreur.
6. Run de l'image IMG avec --rm pour enlever le container à la fin de son éxécution, --detach pour l'éxécuter en arrière plan, --tempfs /tmp pour setup un dossier pour fichier temporaire avec droit d'écriture malgré le --read-only qui suit. La dernière instruction se débarrasse de la sortie de commande.
7. Récupère l'ID du container docker crée par la commande run précédente.
8. Récupère le statut du container grâce à l'ID récupérée.
9. Si le container n'est pas en train de run, alors message d'erreur, sinon, le kill et se débarrasse de la sortie de commande.
10. Remove l'image IMG et se débarrasse de la sortie de la commande.

En résumé, validation.sh crée une image du dockerfile, le run une première fois simplement pour check le user, puis une deuxième fois avec les options souhaitées pour check son statut, si tout se passe bien, le kill puis supprime l'image.

### Modifications

## Dockerfile

Après vérification du repo sur dockerhub, c'est une image basée Alpine.

1. Ajout du paquet alpine pour la gestion utilisateur, qui amène useradd.
2. Modification des droits du script start.sh une fois copié dans le /bin du container pour permettre son éxécution.
3. Création d'un user www avec création de son home directory et assignation de son shell.
12. Impersonation du user www pour la suite, à la place de root.

## start.sh

1. Modification du dossier d'écriture du timestamp pour respecter le read-only du container. Changement pour /tmp qui est défini comme dossier temporaire par l'option --tmpfs /tmp dans le validator.sh lors du run des images.