### PR TITLE
Modification de ma PR pour voir tous les fichiers modifier + explication de script de validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,4 @@ Ainsi, vous pourriez obtenir jusqu'à 25 points (cappés à 20) si vous réalise
 Entrez ici (par PR) vos prénom, nom, et le lien vers votre repository.
 
 1. [Henri Aulait](https://github.com/user/repo) https://github.com/user/repo
+2. [Arthur Hallez](https://github.com/arthur59930/devops-docker-tp) https://github.com/arthur59930/devops-docker-tp

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,6 +4,14 @@
 # This image likely contains network utilities like netstat, ifconfig, etc.
 FROM donch/net-tools
 
+RUN addgroup docker
+
+RUN adduser --disabled-password --gecos '' temporairedockerfile
+
+RUN chmod 754 /home/temporairedockerfile
+
+RUN adduser temporairedockerfile docker
+
 # Copy the start.sh script from the local file system into the /bin directory of the image.
 # This script will be run when a container is started from this image.
 COPY start.sh /bin/start.sh
@@ -12,7 +20,7 @@ COPY start.sh /bin/start.sh
 # This makes the port accessible to processes outside of the container.
 EXPOSE 4321
 
-USER root
+USER temporairedockerfile
 
 # Set /bin/start.sh as the entrypoint of the image.
 # The entrypoint is the command that is run when a container is started from this image.

--- a/src/start.sh
+++ b/src/start.sh
@@ -7,7 +7,7 @@ set -eux
 # 'u' option treats unset variables and parameters as an error.
 # 'x' option prints each command that gets executed to the terminal, useful for debugging.
 
-touch /home/www/started.time
+touch /tmp/started.time
 # This command creates a file named 'started.time' in the '/home/www' directory.
 # If the file already exists, the command does not change the file but updates its access and modification timestamps.
 
@@ -17,7 +17,7 @@ fi
 # This conditional statement checks the exit status of the last command (touch command in this case).
 # If the exit status is not zero, which indicates an error, the script will exit immediately.
 
-date > /home/www/started.time
+date > /tmp/started.time
 # This command writes the current date and time to the 'started.time' file.
 # The '>' operator is used to redirect the output of the 'date' command to the file.
 


### PR DESCRIPTION
```bash
#!/bin/bash
# This is a bash script for validating Docker images and containers.
```
La première ligne `#!/bin/bash` indique que le script doit être exécuté avec l'interpréteur Bash. Le commentaire suivant décrit brièvement l'objectif du script : valider les images et conteneurs Docker.

```bash
set -euo pipefail
# The 'set' command is used to change the values of shell options and set the positional parameters.
# '-e' option will cause the shell to exit if any invoked command fails.
# '-u' option treats unset variables and parameters as an error.
# '-o pipefail' option sets the exit code of a pipeline to that of the rightmost command to exit with a non-zero status.
```
La commande `set -euo pipefail` configure le comportement du script :
- `-e` : Le script s'arrêtera immédiatement si une commande échoue.
- `-u` : Le script traitera l'utilisation de variables non définies comme une erreur et s'arrêtera.
- `-o pipefail` : Le statut de sortie d'une chaîne de commandes sera celui de la dernière commande ayant échoué (non zéro).

```bash
IMG=$(echo img$$)
# Creating a unique image name using the process ID of the current shell.
```
`IMG=$(echo img$$)` crée un nom d'image unique en utilisant l'ID du processus actuel (`$$`). La commande `echo img$$` génère une chaîne de caractères composée de `img` suivi de l'ID du processus, et cette chaîne est assignée à la variable `IMG`.

```bash
docker image build --tag $IMG ./src # --load
# Building a Docker image from the Dockerfile located in the ./src directory.
# The built image is tagged with the unique name generated above.
# The '--load' option ensures the built image is loaded into the Docker daemon only if you use docker buildx.
```
Cette ligne construit une image Docker à partir du fichier Dockerfile situé dans le répertoire `./src`. L'image construite est étiquetée avec le nom unique généré précédemment (`$IMG`). Le commentaire `# --load` mentionne une option qui pourrait être utilisée pour charger l'image dans le démon Docker, mais cette option n'est pas activée dans la commande.

```bash
USR=$(docker container run --rm --entrypoint=whoami $IMG)
# Running a Docker container from the image built above.
# The container is removed after its execution (--rm option).
# The entrypoint of the container is overridden to execute the 'whoami' command.
# The output of 'whoami' (which is the username) is stored in the USR variable.
```
`USR=$(docker container run --rm --entrypoint=whoami $IMG)` exécute un conteneur Docker à partir de l'image construite précédemment. Le conteneur est supprimé après son exécution grâce à l'option `--rm`. L'entrée du conteneur (`entrypoint`) est remplacée par la commande `whoami`, qui renvoie le nom de l'utilisateur exécutant. Le résultat de cette commande est stocké dans la variable `USR`.

```bash
if [[ $USR == "root" ]]; then
  echo "User cannot be root!"
  exit 1
fi
# Checking if the user inside the container is root.
# If it is, an error message is printed and the script exits.
```
Ce bloc vérifie si l'utilisateur à l'intérieur du conteneur est `root`. Si c'est le cas, un message d'erreur est imprimé et le script s'arrête avec un code de sortie `1` (`exit 1`).

```bash
docker container run --rm --detach --tmpfs /tmp --read-only $IMG > /dev/null
# Running a Docker container in detached mode from the image built above.
# The container is removed after its execution (--rm option).
# A temporary filesystem is mounted at /tmp inside the container (--tmpfs option).
# The filesystem of the container is mounted as read-only (--read-only option).
# The output of this command is redirected to /dev/null to suppress it.
```
Cette commande exécute un conteneur Docker en mode détaché (`--detach`) à partir de l'image construite précédemment. Le conteneur est supprimé après son exécution grâce à l'option `--rm`. Un système de fichiers temporaire est monté sur `/tmp` à l'intérieur du conteneur (`--tmpfs /tmp`). Le système de fichiers du conteneur est monté en lecture seule (`--read-only`). La sortie de cette commande est redirigée vers `/dev/null` pour être supprimée.

```bash
ID=$(docker container ls -laq)
# Getting the ID of the last created container.
```
`ID=$(docker container ls -laq)` récupère l'ID du dernier conteneur créé en listant tous les conteneurs en mode silencieux (`-l`) et en affichant uniquement les IDs (`-q`).

```bash
RUNNING=$(docker container inspect -f '{{.State.Status}}' $ID)
# Checking the status of the container with the ID obtained above.
# The status is extracted from the output of 'docker container inspect' command using a format string.
```
`RUNNING=$(docker container inspect -f '{{.State.Status}}' $ID)` inspecte le conteneur avec l'ID récupéré précédemment et extrait son statut en utilisant une chaîne de format (`{{.State.Status}}`). Le statut du conteneur est stocké dans la variable `RUNNING`.

```bash
if [[ $RUNNING == "running" ]]; then
  docker kill $ID > /dev/null
else
  echo "Container cannot run in read-only mode!"
  exit 1
fi
# Checking if the container is running.
# If it is, the container is killed.
# If it's not, an error message is printed and the script exits.
```
Ce bloc vérifie si le conteneur est en cours d'exécution (`$RUNNING == "running"`). Si c'est le cas, le conteneur est tué (`docker kill $ID`) et la sortie est redirigée vers `/dev/null`. Si le conteneur n'est pas en cours d'exécution, un message d'erreur est imprimé et le script s'arrête avec un code de sortie `1` (`exit 1`).

```bash
docker rmi $IMG > /dev/null
# Removing the Docker image built above.
# The output of this command is redirected to /dev/null to suppress it.
```
Enfin, cette ligne supprime l'image Docker construite précédemment (`docker rmi $IMG`) et redirige la sortie vers `/dev/null` pour la supprimer.

### Récapitulatif
Ce script construit une image Docker, vérifie que l'utilisateur à l'intérieur du conteneur n'est pas `root`, exécute un conteneur en mode lecture seule et vérifie s'il peut s'exécuter correctement. Si le conteneur ne peut pas s'exécuter en mode lecture seule, il imprime un message d'erreur. Enfin, il nettoie en supprimant l'image Docker construite.